### PR TITLE
Hide ElevatedFileCopy on a platform where it is unimplemented

### DIFF
--- a/modules/gin/utilities/elevatedfilecopy.cpp
+++ b/modules/gin/utilities/elevatedfilecopy.cpp
@@ -5,6 +5,12 @@
 
  ==============================================================================*/
 
+#if JUCE_LINUX
+
+// TODO: no implementation for Linux yet
+
+#else
+
 #if JUCE_MAC
 
 ElevatedFileCopy::Result runWinPermissions (String cmd, StringArray params)
@@ -285,3 +291,5 @@ void ElevatedFileCopy::clear()
 {
 	filesToCopy.clear();
 }
+
+#endif

--- a/modules/gin/utilities/elevatedfilecopy.h
+++ b/modules/gin/utilities/elevatedfilecopy.h
@@ -7,6 +7,12 @@
 
 #pragma once
 
+#if JUCE_LINUX
+
+// TODO: no implementation for Linux yet
+
+#else
+
 /** Copies files, creating folders where required
     requesting admin access only if required
   */
@@ -62,3 +68,5 @@ private:
 
     JUCE_LEAK_DETECTOR (ElevatedFileCopy)
 };
+
+#endif


### PR DESCRIPTION
This class is mostly unimplemented on the Linux platform.
It's a problem to have its declaration visible, because it creates a linking error with gcc at the end of a plugin build, even when it is not called.