### PR TITLE
Fixed applyHueSaturationLightness to respect original image alpha.

### DIFF
--- a/modules/gin/images/imageeffects.cpp
+++ b/modules/gin/images/imageeffects.cpp
@@ -659,12 +659,12 @@ void applyHueSaturationLightness (Image& img, float hueIn, float saturation, flo
 
             if (lightness > 0)
             {
-                auto blended = blend (PixelARGB (toByte ((lightness * 255) / 100), 255, 255, 255), convert<T, PixelARGB> (*s));
+                auto blended = blend (PixelARGB (toByte ((lightness * 255) / 100 * (a / 255.0)), 255, 255, 255), convert<T, PixelARGB> (*s));
                 *s = convert<PixelARGB, T> (blended);
             }
             else if (lightness < 0)
             {
-                auto blended = blend (PixelARGB (toByte ((-lightness * 255) / 100), 0, 0, 0), convert<T, PixelARGB> (*s));
+                auto blended = blend (PixelARGB (toByte ((-lightness * 255) / 100 * (a / 255.0)), 0, 0, 0), convert<T, PixelARGB> (*s));
                 *s = convert<PixelARGB, T> (blended);
             }
 


### PR DESCRIPTION
Hi Roland,
with your original implementation of this method applying a `lightness` value other than zero would affect the whole image bounds:
![image](https://user-images.githubusercontent.com/5970482/64478828-9375db00-d1ae-11e9-9bb9-c6ce988c2058.png)
with this small change the original image alpha level is respected giving this result:
![image](https://user-images.githubusercontent.com/5970482/64478848-bc966b80-d1ae-11e9-8bb4-997ebaeb8460.png)
I hope I didn't overlook anything important.
Thanks,
Rich