### PR TITLE
Addition of DownloadManager::DownloadResult::saveToFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 *.out
 *.app
 
+# MacOS specifics
+*.DS_Store
+
 *.xcuserstate
 
 *.xcbkptlist

--- a/examples/Demo/Source/MainComponent.cpp
+++ b/examples/Demo/Source/MainComponent.cpp
@@ -717,6 +717,103 @@ struct DownloadManagerDemo : public juce::Component,
 };
 
 //==============================================================================
+struct DownloadManagerToSaveToFileDemo : public juce::Component,
+                                         private juce::Button::Listener
+{
+    DownloadManagerToSaveToFileDemo():
+        downloadButton ("Choose File"),
+        openButton ("Open File"),
+        fileChooser ("Download random picture to...", juce::File(), "*.jpg")
+    {
+        setName ("Download and Save");
+        downloadManager.setConcurrentDownloadLimit (1);
+        downloadManager.setProgressInterval (1);
+        downloadManager.enableGzipDeflate (true);
+        downloadManager.setQueueFinishedCallback([] {
+            DBG("All done!");
+        });
+        downloadButton.addListener (this);
+        addAndMakeVisible (downloadButton );
+        openButton.addListener (this);
+        openButton.setEnabled (false);
+        addAndMakeVisible (openButton);
+        lastResult.setJustificationType (juce::Justification::centred);
+        addAndMakeVisible (lastResult);
+    }
+    
+    void resized() override
+    {
+        int itemWidth = getWidth() - 20;
+        static constexpr int itemHeight = 30;
+        auto centre = getLocalBounds().getCentre();
+        lastResult.setBounds (centre.getX() - itemWidth / 2, centre.getY() - itemHeight / 2, itemWidth, itemHeight);
+        downloadButton.setBounds (lastResult.getBounds().withY (lastResult.getY() - itemHeight));
+        openButton.setBounds (lastResult.getBounds().withY (lastResult.getBottom()));
+    }
+    
+    void buttonClicked (juce::Button* b) override
+    {
+        if (b == &downloadButton)
+        {
+            fileChooser.launchAsync (juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::saveMode, [&] (const juce::FileChooser&)
+            {
+                file = fileChooser.getResult();
+                openButton.setEnabled (false);
+                
+                if (file != juce::File())
+                {
+                    juce::String url = juce::String::formatted ("https://picsum.photos/id/%d/%d/%d/", juce::Random::getSystemRandom().nextInt (500), getWidth(), getHeight());
+                    
+                    auto progressCb = [&] (juce::int64 current, juce::int64 total, juce::int64)
+                    {
+                        updateText (juce::String::formatted ("%d%", int (double (current) / double (total) * 100.0)));
+                    };
+                    
+                    auto completionCb = [&]( gin::DownloadManager::DownloadResult result )
+                    {
+                        if (!result.ok)
+                            updateText ("Error: download failed!", true);
+                        else if (result.saveToFile (file))
+                            updateText ("Success: picture saved to " + file.getFullPathName());
+                        else
+                            updateText ("Error: could not save to " + file.getFullPathName());
+                        downloadButton.setEnabled (true);
+                        openButton.setEnabled (result.ok && file.existsAsFile());
+                    };
+
+                    downloadButton.setEnabled (false);
+                    downloadManager.startAsyncDownload (url, completionCb, progressCb);
+                }
+                else
+                {
+                    updateText ("");
+                }
+            });
+        }
+        else if (b == &openButton)
+        {
+            if (file.existsAsFile())
+                file.startAsProcess();
+            else
+                openButton.setEnabled (false);
+        }
+    }
+    
+    void updateText (juce::String msg, bool isError = false )
+    {
+        lastResult.setColour (juce::Label::ColourIds::textColourId, isError ? juce::Colours::red : juce::Colours::green);
+        lastResult.setText (msg, juce::dontSendNotification);
+    }
+    
+    juce::TextButton downloadButton;
+    juce::TextButton openButton;
+    juce::Label lastResult;
+    juce::FileChooser fileChooser;
+    juce::File file;
+    gin::DownloadManager downloadManager {3 * 1000, 3 * 1000};
+};
+
+//==============================================================================
 #if defined JUCE_MAC || defined JUCE_WINDOWS || defined JUCE_LINUX
 struct FileSystemWatcherDemo : public juce::Component,
                                private gin::FileSystemWatcher::Listener
@@ -1350,6 +1447,7 @@ MainContentComponent::MainContentComponent()
     demoComponents.add (new ElevatedFileCopyDemo());
    #endif
     demoComponents.add (new DownloadManagerDemo());
+    demoComponents.add (new DownloadManagerToSaveToFileDemo());
     demoComponents.add (new ImageEffectsDemo());
     demoComponents.add (new BoxBlurDemo());
    #if defined JUCE_MAC || defined JUCE_WINDOWS || defined JUCE_LINUX

--- a/modules/gin/utilities/gin_downloadmanager.cpp
+++ b/modules/gin/utilities/gin_downloadmanager.cpp
@@ -61,6 +61,22 @@ DownloadManager::DownloadResult DownloadManager::blockingDownload (juce::URL url
     return download.result;
 }
 
+bool DownloadManager::DownloadResult::saveToFile (const juce::File& file, bool overwrite)
+{
+    // Bail if the DownloadResult failed or is empty
+    if (!ok || data.getSize() == 0) return false;
+    // Bail if the file exists and cannot overwrite
+    if (!overwrite && file.existsAsFile()) return false;
+    // Bail if the file cannot be created
+    if (file.create().failed()) return false;
+    // Write the MemoryBlock to the file
+    FileOutputStream outputStream (file);
+    bool success = outputStream.write (data.getData(), data.getSize());
+    if (success) outputStream.flush();
+    // Return the write operation success
+    return success;
+}
+
 int DownloadManager::startAsyncDownload (juce::String url, juce::String postData,
                                          std::function<void (DownloadResult)> completionCallback,
                                          std::function<void (juce::int64, juce::int64, juce::int64)> progressCallback,

--- a/modules/gin/utilities/gin_downloadmanager.cpp
+++ b/modules/gin/utilities/gin_downloadmanager.cpp
@@ -70,7 +70,7 @@ bool DownloadManager::DownloadResult::saveToFile (const juce::File& file, bool o
     // Bail if the file cannot be created
     if (file.create().failed()) return false;
     // Write the MemoryBlock to the file
-    FileOutputStream outputStream (file);
+    juce::FileOutputStream outputStream (file);
     bool success = outputStream.write (data.getData(), data.getSize());
     if (success) outputStream.flush();
     // Return the write operation success

--- a/modules/gin/utilities/gin_downloadmanager.cpp
+++ b/modules/gin/utilities/gin_downloadmanager.cpp
@@ -67,6 +67,8 @@ bool DownloadManager::DownloadResult::saveToFile (const juce::File& file, bool o
     if (!ok || data.getSize() == 0) return false;
     // Bail if the file exists and cannot overwrite
     if (!overwrite && file.existsAsFile()) return false;
+    // Delete the existing file (if any), bail on error
+    if (!file.deleteFile()) return false;
     // Bail if the file cannot be created
     if (file.create().failed()) return false;
     // Write the MemoryBlock to the file

--- a/modules/gin/utilities/gin_downloadmanager.h
+++ b/modules/gin/utilities/gin_downloadmanager.h
@@ -81,6 +81,8 @@ public:
         bool ok = false;
         int httpCode = 0;
         juce::StringPairArray responseHeaders;
+        
+        bool saveToFile (const juce::File& file, bool overwrite = true);
     };
 
     //==============================================================================


### PR DESCRIPTION
DownloadManager is often used to download files. I added a simple `saveToFile` method to `DownloadManager::DownloadResult` that does just that.
I also added a demo for it, although it is pretty straightforward.