### PR TITLE
Make DownloadManager::downloads thread safe to avoid potential heap corruption

### DIFF
--- a/modules/gin/utilities/gin_downloadmanager.h
+++ b/modules/gin/utilities/gin_downloadmanager.h
@@ -155,7 +155,7 @@ private:
 
     double retryDelay = 0.0;
     int runningDownloads = 0, maxDownloads = 100;
-    juce::OwnedArray<Download> downloads;
+    juce::OwnedArray<Download, juce::CriticalSection> downloads;
     std::function<void ()> queueFinishedCallback;
     bool gzipDeflate = true;
     std::atomic<bool> pause { false };


### PR DESCRIPTION
DownloadManager::downloads is a juce::OwnedArray object which is not thread safe by default. However, it can be made thread safe by following the advice at the top of juce_OwnedArray.h:
"To make all the array's methods thread-safe, pass in "CriticalSection" as the templated TypeOfCriticalSectionToUse parameter, instead of the default DummyCriticalSection."
This avoids potential heap corruption when many download threads are being created.