### PR TITLE
make Gin compile on Windows when CharacterSet is set to Unicode

### DIFF
--- a/modules/gin/3rdparty/muParser/muParserDef.h
+++ b/modules/gin/3rdparty/muParser/muParserDef.h
@@ -57,21 +57,14 @@
 */
 //#define MUP_USE_OPENMP
 
-#if defined(_UNICODE)
-  /** \brief Definition of the basic parser string type. */
-  #define MUP_STRING_TYPE std::wstring
-
-  #if !defined(_T)
-    #define _T(x) L##x
-  #endif // not defined _T
-#else
-  #ifndef _T
-  #define _T(x) x
-  #endif
-
-  /** \brief Definition of the basic parser string type. */
-  #define MUP_STRING_TYPE std::string
+// NOTE: UNICODE support disabled
+#ifndef _T
+#define _T(x) x
 #endif
+
+/** \brief Definition of the basic parser string type. */
+#define MUP_STRING_TYPE std::string
+
 
 #if defined(_DEBUG)
   /** \brief Debug macro to force an abortion of the programm with a certain message.
@@ -104,26 +97,7 @@
 
 namespace mu
 {
-#if defined(_UNICODE)
-
-  //------------------------------------------------------------------------------
-  /** \brief Encapsulate wcout. */
-  inline std::wostream& console()
-  {
-    return std::wcout;
-  }
-
-  /** \brief Encapsulate cin. */
-  inline std::wistream& console_in()
-  {
-    return std::wcin;
-  }
-
-#else
-
   /** \brief Encapsulate cout.
-
-    Used for supporting UNICODE more easily.
   */
   inline std::ostream& console()
   {
@@ -131,15 +105,11 @@ namespace mu
   }
 
   /** \brief Encapsulate cin.
-
-    Used for supporting UNICODE more easily.
   */
   inline std::istream& console_in()
   {
     return std::cin;
   }
-
-#endif
 
   //------------------------------------------------------------------------------
   /** \brief Bytecode values.

--- a/modules/gin/utilities/gin_sharedmemory.cpp
+++ b/modules/gin/utilities/gin_sharedmemory.cpp
@@ -31,7 +31,7 @@ public:
         if (fileMapping == nullptr)
             fileMapping = CreateFileMappingW (INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sz, shareName.toWideCharPointer());
 
-        if (HMODULE dll = LoadLibrary ("ntdll.dll"))
+        if (HMODULE dll = LoadLibraryA ("ntdll.dll"))
         {
             NTQUERYSECTION ntQuerySection = (NTQUERYSECTION) GetProcAddress (dll, "NtQuerySection");
             if (ntQuerySection != nullptr)


### PR DESCRIPTION
It was not possible to compile Gin on Windows when `_UNICODE` compiler definition was set.
Compilation errors where caused by 2 things:

- Usage of `LoadLibrary` macro in `gin_sharedmemory.cpp` which expanded to `LoadLibraryW` call which expected wide string as an argument. I've decided to follow an approach already used in Juce and directly called `LoadLibraryA` function which accepts "normal" string.

- Unicode support in muParser. Basically, muParser was choosing `std::wstring` over `std::string` in its `mu::string_type`, but Gin's code was not compatible with `std::wstring`. It was possible to add support for `std::wstring`, although it would have complicated the code, so the decision was made to _remove_ special Unicode handling from muParser.

One can verify that Gin is compiling with defined Unicode character set by adding `/p:CharacterSet=Unicode` to [ci/win/build.bat#L25](https://github.com/FigBug/Gin/blob/master/ci/win/build.bat#L25)