### PR TITLE
Allow access to the value object of the PropertyComponentBase

### DIFF
--- a/modules/gin_gui/components/gin_propertycomponents.h
+++ b/modules/gin_gui/components/gin_propertycomponents.h
@@ -18,6 +18,10 @@ public:
         value.addListener (this);
     }
 
+    juce::Value& getValueObject() {
+        return value;
+    }
+
 protected:
     void valueChanged (juce::Value&) override
     {


### PR DESCRIPTION
Just like the JUCE components allow us to. This is useful to call getPropertyObject().referTo() e.g. to bind the color property editor to a value in a ValueTree.
