### PR TITLE
Fix Linux bugs for gin_filesystemwatcher

### DIFF
--- a/modules/gin/utilities/gin_filesystemwatcher.cpp
+++ b/modules/gin/utilities/gin_filesystemwatcher.cpp
@@ -131,7 +131,7 @@ public:
         const struct inotify_event* iNotifyEvent;
         char* ptr;
 
-        while (true)
+        while (! threadShouldExit())
         {
             int numRead = read (fd, buf, BUF_LEN);
 
@@ -151,7 +151,7 @@ public:
                 else if (iNotifyEvent->mask & IN_MOVED_TO)    e.fsEvent = FileSystemEvent::fileRenamedNewName;
                 else if (iNotifyEvent->mask & IN_DELETE)      e.fsEvent = FileSystemEvent::fileDeleted;
 
-
+                juce::ScopedLock sl (lock);
                 bool duplicateEvent = false;
                 for (auto existing : events)
                 {
@@ -166,6 +166,7 @@ public:
                     events.add (std::move (e));
             }
 
+            juce::ScopedLock sl (lock);
             if (events.size() > 0)
                 triggerAsyncUpdate();
         }


### PR DESCRIPTION
This fixes 2 bugs:

1. The ScopedLock in handleAsyncUpdate was never really used, since it didn't get locked anywhere else. This lead to data-races and potential crashes
2. We now check if the thread was requested to quit, similar to what you did on Windows. Not doing this can lead to shutdown bugs.