### PR TITLE
add ProcessorOptions::withoutUpdateChecker

### DIFF
--- a/modules/gin_plugin/plugin/gin_processor.h
+++ b/modules/gin_plugin/plugin/gin_processor.h
@@ -72,6 +72,16 @@ public:
 
         return self;
     }
+
+    ProcessorOptions withoutUpdateChecker() const
+    {
+        auto self = *this;
+
+        self.useUpdateChecker = false;
+
+        return self;
+
+    }
 };
 
 //==============================================================================


### PR DESCRIPTION
(please lmk if you have a better pattern to use here - i read through the examples and couldn't find a simple way)

this pr makes it possible to disable the update checker in the `gin::Processor` ctor, eg:

```cpp
SynthAudioProcessor::SynthAudioProcessor() : gin::Processor (false, gin::ProcessorOptions().withoutUpdateChecker())
```


