### PR TITLE
Set `GIN_HAS_SIMD` to 1 only on supported architectures

### DIFF
--- a/modules/gin_simd/gin_simd.h
+++ b/modules/gin_simd/gin_simd.h
@@ -79,8 +79,10 @@ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE("-Wimplicit-float-conversion",
 #ifndef GIN_HAS_SIMD
  #ifdef JUCE_32BIT
   #define GIN_HAS_SIMD 0
- #else
+ #elif defined(JUCE_INTEL) || defined(JUCE_ARM)
   #define GIN_HAS_SIMD 1
+ #else
+  #define GIN_HAS_SIMD 0
  #endif
 #endif
 


### PR DESCRIPTION
[MIPP](https://github.com/FigBug/Gin/tree/master/modules/gin_simd/mipp) only supports x86 and ARM, but `GIN_HAS_SIMD` is defined as 1 on other architectures as well, like PowerPC. This leads to compilation errors: for example, [gin\_bandlimitedlookuptable.h](https://github.com/FigBug/Gin/blob/f4331da4af33c58defae01341c7a7bf44c67e2a1/modules/gin_dsp/dsp/gin_bandlimitedlookuptable.h#L82) asserts `mipp::N<float>() == 4`, but `mipp::N()` unconditionally returns 1 on any architecture besides x86 and ARM.

This PR ensures `GIN_HAS_SIMD` is 0 on architectures that don't support SIMD.