### PR TITLE
Fixed memory leak reading JPEG metadata

### DIFF
--- a/modules/gin_metadata/metadata/gin_imagemetadata.cpp
+++ b/modules/gin_metadata/metadata/gin_imagemetadata.cpp
@@ -91,7 +91,7 @@ static bool loadJPEGMetadataFromStream (juce::OwnedArray<ImageMetadata>& metadat
 
             marker = marker->next;
         }
-
+        jpeg_destroy_decompress(&jpegDecompStruct);
     }
     return metadata.size() > 0;
 }


### PR DESCRIPTION
After calling `ImageMetadata::getFromImage` for a JPEG file, a memory leak was being reported.

`Detected memory leaks!
Dumping objects ->
{26326} normal block at 0x00000255720A4E80, 16312 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 20 01 00 00 00 00 00 00 
{26325} normal block at 0x0000025571CD40F0, 32224 bytes long.
 Data: < & qU    }      > F0 26 F4 71 55 02 00 00 C8 7D 00 00 00 00 00 00 
{26324} normal block at 0x0000025571F426F0, 1320 bytes long.
 Data: <  8uU           > 00 98 38 75 55 02 00 00 10 05 00 00 00 00 00 00 
{26323} normal block at 0x0000025575389800, 672 bytes long.
 Data: < ^!uU           > F0 5E 21 75 55 02 00 00 88 02 00 00 00 00 00 00 
{26322} normal block at 0x0000025575215EF0, 72 bytes long.
 Data: < 2ojU   0       > 10 32 6F 6A 55 02 00 00 30 00 00 00 00 00 00 00 
{26321} normal block at 0x000002556A6F3210, 1192 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 90 04 00 00 00 00 00 00 
{26320} normal block at 0x0000025571D35E60, 1888 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 E0 06 00 00 00 00 00 00 
{26319} normal block at 0x0000025571EFFBE0, 152 bytes long.
 Data: <                > A0 E7 C6 1F F6 7F 00 00 90 EA C6 1F F6 7F 00 00 
Object dump complete.`

Looking at [loadJPEGMetadataFromStream](https://github.com/FigBug/Gin/blob/f8e8c344a1194af85582ae0004c642603479169f/modules/gin_metadata/metadata/gin_imagemetadata.cpp#L47), `jpeg_create_decompress` seemed to need a closing call to `jpeg_destroy_decompress.`

Adding this function call resolved the reported memory leak.