### PR TITLE
Update filesystemwatcher deprecated MacOS API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,13 @@
 Debug
 Release
 .vs
+.idea
 *.user
 
 xcuserdata
 Builds
+cmake-build-debug
+cmake-build-release
 JuceLibraryCode
 juce
 bin

--- a/modules/gin/utilities/gin_filesystemwatcher.cpp
+++ b/modules/gin/utilities/gin_filesystemwatcher.cpp
@@ -21,11 +21,12 @@ public:
         context.release         = nil;
         context.copyDescription = nil;
 
+        dispatch_queue_t queue = dispatch_queue_create("com.gin.filesystemwatcher", DISPATCH_QUEUE_SERIAL);
         stream = FSEventStreamCreate (kCFAllocatorDefault, callback, &context, (CFArrayRef)paths, kFSEventStreamEventIdSinceNow, 0.05,
                                       kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents);
         if (stream)
         {
-            FSEventStreamScheduleWithRunLoop (stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+            FSEventStreamSetDispatchQueue(stream, queue);
             FSEventStreamStart (stream);
         }
 
@@ -36,7 +37,7 @@ public:
         if (stream)
         {
             FSEventStreamStop (stream);
-            FSEventStreamUnscheduleFromRunLoop (stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+            FSEventStreamSetDispatchQueue(stream, nullptr);
             FSEventStreamInvalidate (stream);
             FSEventStreamRelease (stream);
         }


### PR DESCRIPTION
Hi, 

I made these light changes based on what was recommended by Apple. I'm by no means an Objective-C developer but it builds without warnings, it runs fine and shuts down gracefully, I can let you review and test it, I just have no idea about the retro-compatibility.

Cheers !