### PR TITLE
FilesystemWatcher : warnings and housekeeping

### DIFF
--- a/examples/Demo/Source/MainComponent.cpp
+++ b/examples/Demo/Source/MainComponent.cpp
@@ -38,7 +38,7 @@ public:
 };
 
 //==============================================================================
-struct TextRenderDemo : public juce::Component
+struct TextRenderDemo final : public juce::Component
 {
     TextRenderDemo()
     {
@@ -929,7 +929,7 @@ struct FileSystemWatcherDemo : public juce::Component,
         events.setBounds (rc);
     }
 
-    void folderChanged (juce::File f) override
+    void folderChanged (const juce::File& f) override
     {
         juce::Array<juce::File> files;
         f.findChildFiles (files, juce::File::findFiles, false);
@@ -938,13 +938,13 @@ struct FileSystemWatcherDemo : public juce::Component,
         contents.clear();
 
         juce::String txt;
-        for (auto ff : files)
+        for (const auto& ff : files)
             txt += ff.getFileName() + "\n";
 
         contents.setText (txt);
     }
 
-    void fileChanged (juce::File f, gin::FileSystemWatcher::FileSystemEvent fsEvent) override
+    void fileChanged (const juce::File& f, gin::FileSystemWatcher::FileSystemEvent fsEvent) override
     {
         auto eventToString = [] (gin::FileSystemWatcher::FileSystemEvent evt) -> juce::String
         {

--- a/modules/gin/utilities/gin_filesystemwatcher.h
+++ b/modules/gin/utilities/gin_filesystemwatcher.h
@@ -48,6 +48,7 @@ public:
     */
     enum FileSystemEvent
     {
+        undefined,
         fileCreated,
         fileDeleted,
         fileUpdated,
@@ -65,11 +66,11 @@ public:
         /* Called when any file in the listened to folder changes with the name of
            the folder that has changed. For example, use this for a file browser that
            needs to refresh any time a file changes */
-        virtual void folderChanged (const juce::File) {}
+        virtual void folderChanged (const juce::File&) {}
 
         /* Called for each file that has changed and how it has changed. Use this callback
            if you need to reload a file when it's contents change */
-        virtual void fileChanged (const juce::File, FileSystemEvent) {}
+        virtual void fileChanged (const juce::File&, FileSystemEvent) {}
     };
 
     /** Registers a listener to be told when things happen to the text.

--- a/modules/gin_gui/utilities/gin_layout.cpp
+++ b/modules/gin_gui/utilities/gin_layout.cpp
@@ -343,21 +343,21 @@ juce::Component* Layout::setBounds (const juce::String& currentPath, const juce:
 }
 
 #if ! JUCE_IOS
-void Layout::fileChanged (const juce::File f, gin::FileSystemWatcher::FileSystemEvent)
+void Layout::fileChanged (const juce::File& f, gin::FileSystemWatcher::FileSystemEvent)
 {
     if (f == layoutFile)
-        if (auto str = layoutFile.loadFileAsString(); str.isNotEmpty())
+        if (const auto str = layoutFile.loadFileAsString(); str.isNotEmpty())
             parseLayout (str);
 }
 #endif
 
-std::map<juce::String, juce::Component*> Layout::findAllComponents()
+std::map<juce::String, juce::Component*> Layout::findAllComponents() const
 {
     std::map<juce::String, juce::Component*> components;
 
-    std::function<void (juce::Component&)> findAll = [&] (juce::Component& p)
+    std::function<void (juce::Component&)> findAll = [&] (const juce::Component& p)
     {
-        for (auto c : p.getChildren())
+        for (auto* c : p.getChildren())
         {
             if (c->getName().isNotEmpty())
                 components[getComponentPath (parent, *c)] = c;

--- a/modules/gin_gui/utilities/gin_layout.h
+++ b/modules/gin_gui/utilities/gin_layout.h
@@ -28,10 +28,10 @@ private:
     juce::Component* setBounds (const juce::String& currentPath, const juce::String& id, int idIdx, const juce::var& component);
 
    #if ! JUCE_IOS
-    void fileChanged (const juce::File, gin::FileSystemWatcher::FileSystemEvent) override;
+    void fileChanged (const juce::File&, gin::FileSystemWatcher::FileSystemEvent) override;
    #endif
 
-    std::map<juce::String, juce::Component*> findAllComponents();
+    std::map<juce::String, juce::Component*> findAllComponents() const;
 
    #if ! JUCE_IOS
     gin::FileSystemWatcher watcher;


### PR DESCRIPTION
Hi, 

I noticed on Linux that fileUpdated was never triggered, so I debugged and realized the MODIFIED flag from inotify was triggered. I also added an `undefined` event type to avoid undefined behaviour on uninitizalized type and triggering invalid events.

I removed a few useless copies of juce::File, it's a breaking change cause it changes the signature of the virtual method `fileChanged`.

Also some housekeeping with a few warning fixes. 

Built and tested on Arch Linux and Windows 11 with clang.

Open to discussion !