### PR TITLE
Exclude FileSystemWatcher from Android build.

### DIFF
--- a/modules/gin_gui/utilities/gin_layout.cpp
+++ b/modules/gin_gui/utilities/gin_layout.cpp
@@ -126,14 +126,14 @@ static juce::String getComponentPath (juce::Component& parent, juce::Component& 
 Layout::Layout (juce::Component& p) : parent (p)
 {
     setupParser();
-   #if ! JUCE_IOS
+   #if ! JUCE_IOS && ! JUCE_ANDROID
     watcher.addListener (this);
    #endif
 }
 
 Layout::~Layout()
 {
-   #if ! JUCE_IOS
+   #if ! JUCE_IOS && ! JUCE_ANDROID
     watcher.removeListener (this);
    #endif
 }
@@ -202,7 +202,7 @@ void Layout::setLayout (const juce::String& filename, const juce::File& source)
                 if (auto rawLayout = source.loadFileAsString(); rawLayout.isNotEmpty() && parseLayout (rawLayout))
                 {
                     layoutFile = source;
-                   #if ! JUCE_IOS
+                   #if ! JUCE_IOS && ! JUCE_ANDROID
                     watcher.addFolder (source.getParentDirectory());
                    #endif
                     break;
@@ -342,7 +342,7 @@ juce::Component* Layout::setBounds (const juce::String& currentPath, const juce:
     return curComponent;
 }
 
-#if ! JUCE_IOS
+#if ! JUCE_IOS && ! JUCE_ANDROID
 void Layout::fileChanged (const juce::File& f, gin::FileSystemWatcher::FileSystemEvent)
 {
     if (f == layoutFile)

--- a/modules/gin_gui/utilities/gin_layout.h
+++ b/modules/gin_gui/utilities/gin_layout.h
@@ -4,13 +4,13 @@
 /** Layout components with json, supports hot reloading
  */
 class Layout
-#if ! JUCE_IOS
+#if ! JUCE_IOS && ! JUCE_ANDROID
     : public FileSystemWatcher::Listener
 #endif
 {
 public:
     Layout (juce::Component&);
-   #if JUCE_IOS
+   #if JUCE_IOS || JUCE_ANDROID
     ~Layout();
    #else
     ~Layout() override;
@@ -27,13 +27,13 @@ private:
     void doComponent (const juce::String& currentPath, const juce::var& components);
     juce::Component* setBounds (const juce::String& currentPath, const juce::String& id, int idIdx, const juce::var& component);
 
-   #if ! JUCE_IOS
+   #if ! JUCE_IOS && ! JUCE_ANDROID
     void fileChanged (const juce::File&, gin::FileSystemWatcher::FileSystemEvent) override;
    #endif
 
     std::map<juce::String, juce::Component*> findAllComponents() const;
 
-   #if ! JUCE_IOS
+   #if ! JUCE_IOS && ! JUCE_ANDROID
     gin::FileSystemWatcher watcher;
    #endif
 

--- a/modules/gin_plugin/components/gin_plugineditor.cpp
+++ b/modules/gin_plugin/components/gin_plugineditor.cpp
@@ -34,7 +34,7 @@ void UpdateChecker::timerCallback()
 
 void UpdateChecker::run()
 {
-  #if ! JUCE_IOS
+  #if ! JUCE_IOS && ! JUCE_ANDROID
     juce::URL versionsUrl = juce::URL (slProc.processorOptions.updatesURL).withParameter ("plugin", slProc.processorOptions.pluginName).withParameter ("version", slProc.processorOptions.pluginVersion);
     juce::XmlDocument doc (versionsUrl.readEntireTextStream());
     if (std::unique_ptr<juce::XmlElement> root = doc.getDocumentElement())
@@ -105,7 +105,7 @@ void NewsChecker::timerCallback()
 
 void NewsChecker::run()
 {
-    #if ! JUCE_IOS
+    #if ! JUCE_IOS && ! JUCE_ANDROID
     juce::XmlDocument doc (juce::URL ("https://socalabs.com/feed/").readEntireTextStream());
     if (std::unique_ptr<juce::XmlElement> root = doc.getDocumentElement())
     {

--- a/modules/gin_plugin/plugin/gin_processor.cpp
+++ b/modules/gin_plugin/plugin/gin_processor.cpp
@@ -61,8 +61,10 @@ void Processor::init()
     state.getOrCreateChildWithName ("instance", nullptr);
     loadAllPrograms();
 
+#if ! JUCE_IOS && ! JUCE_ANDROID
     watcher.addListener (this);
     watcher.addFolder (getProgramDirectory());
+#endif
 }
 
 juce::PropertiesFile* Processor::getSettings()
@@ -340,12 +342,14 @@ bool Processor::hasProgram (juce::String name)
     return false;
 }
 
+#if ! JUCE_IOS && ! JUCE_ANDROID
 void Processor::folderChanged (const juce::File&)
 {
     auto now = juce::Time::getCurrentTime();
     if (now - lastProgramsUpdated > juce::RelativeTime::seconds (1.0))
         startTimer (150);
 }
+#endif
 
 void Processor::timerCallback()
 {

--- a/modules/gin_plugin/plugin/gin_processor.h
+++ b/modules/gin_plugin/plugin/gin_processor.h
@@ -100,7 +100,9 @@ public:
 */
 class Processor : public ProcessorBaseClass,
                   public juce::ChangeBroadcaster,
+#if ! JUCE_IOS && ! JUCE_ANDROID
                   private FileSystemWatcher::Listener,
+#endif
                   private juce::Timer
 {
 public:
@@ -208,7 +210,9 @@ protected:
     void extractProgram (const juce::String& name, const void* data, int sz);
 
 private:
+#if ! JUCE_IOS && ! JUCE_ANDROID
     void folderChanged (const juce::File&) override;
+#endif
     void timerCallback() override;
 
     std::unique_ptr<juce::PropertiesFile> settings;
@@ -222,7 +226,9 @@ private:
 
     void updateParams();
 
+#if ! JUCE_IOS && ! JUCE_ANDROID
     FileSystemWatcher watcher;
+#endif
 
     juce::String currentProgramName;
     int maxPrograms = 0;


### PR DESCRIPTION
I'm trying to get [AudiblePlanets](https://github.com/gregrecco67/AudiblePlanets) running on Android (it partially does already), but it fails to build at Gin due to missing reference to `FileSystemWatcher`.

Since Gin already exclude `JUCE_IOS`, it would be fair to exclude that class from Android builds too.