### PR TITLE
Add support for custom headers in AsyncWebsocket

### DIFF
--- a/modules/gin_network/network/gin_asyncwebsocket.h
+++ b/modules/gin_network/network/gin_asyncwebsocket.h
@@ -15,7 +15,7 @@ class AsyncWebsocket : public juce::Thread
 {
 public:
     //==============================================================================
-    AsyncWebsocket (const juce::URL url);
+    AsyncWebsocket(const juce::URL url, const juce::StringPairArray& customHeaders = {});
     ~AsyncWebsocket() override;
 
     //==============================================================================
@@ -41,6 +41,7 @@ private:
     void process();
 
     juce::URL url;
+    juce::StringPairArray customHeaders;
 
     //==============================================================================
     enum MessageType

--- a/modules/gin_network/network/gin_websocket.h
+++ b/modules/gin_network/network/gin_websocket.h
@@ -44,6 +44,8 @@ class WebSocket
     static WebSocket* fromURLNoMask (const juce::String& url, const juce::String& origin = {});
     static WebSocket* fromURL (const juce::String& url, bool useMask, const juce::String& origin);
 
+    static WebSocket* fromURL (const juce::String& url, const juce::String& origin, const juce::StringPairArray& customHeaders);
+
     ~WebSocket();
 
     bool readIncoming();


### PR DESCRIPTION
I've updated Gin AsyncWebsocket to support custom headers when creating a websocket connection, so I can now replicate what I was doing in Python, i.e.:

```python
ws = create_connection(
    WS_URL,
    header=[
        f'Authorization: Bearer {API_KEY}',
        'OpenAI-Beta: realtime=v1'
    ]
)
```

In C++:
```c++
    juce::String apiKey = "...";
    
    juce::URL openAIURL("wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01");

    juce::StringPairArray customHeaders;
    customHeaders.set("Authorization", "Bearer " + apiKey);
    customHeaders.set("OpenAI-Beta", "realtime=v1");

    websocket = std::make_unique<gin::AsyncWebsocket>(openAIURL, customHeaders);
```